### PR TITLE
Update blog posts to also have a numbered path.

### DIFF
--- a/.github/workflows/develop-build-deploy.yml
+++ b/.github/workflows/develop-build-deploy.yml
@@ -17,6 +17,8 @@ jobs:
         run: touch .env; echo "NEXT_PUBLIC_SERVICE_ID = ${{secrets.NEXT_PUBLIC_SERVICE_ID}}" >> .env; echo "NEXT_PUBLIC_TEMPLATE_ID = ${{secrets.NEXT_PUBLIC_TEMPLATE_ID}}" >> .env; echo "NEXT_PUBLIC_PUBLIC_KEY = ${{secrets.NEXT_PUBLIC_PUBLIC_KEY}}" >> .env
       - name: Build project assets
         run: npm run build
+      - name: Copy .htaccess to out directory
+        run: cp src/util/.htaccess out/.htaccess
       - name: Cache out directory
         uses: actions/cache@v4
         with:

--- a/.github/workflows/production-build-deploy.yml
+++ b/.github/workflows/production-build-deploy.yml
@@ -15,6 +15,8 @@ jobs:
         run: npm install
       - name: Build project assets
         run: npm run build
+      - name: Copy .htaccess to out directory
+        run: cp src/util/.htaccess out/.htaccess
       - name: Cache out directory
         uses: actions/cache@v4
         with:

--- a/content/blog/Why-I-Added-a-Blog-to-My-Personal-Site.md
+++ b/content/blog/Why-I-Added-a-Blog-to-My-Personal-Site.md
@@ -1,6 +1,7 @@
 ---
 title: "Why I Added a Blog to My Personal Site"
 date: "2025-12-19"
+postNumber: 1
 tags: ["personal-site", "nextjs", "blog"]
 ---
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -6,31 +6,51 @@ import { BlogPostMeta } from "./types";
 const blogDir = path.join(process.cwd(), "content/blog");
 
 export function getAllPosts(): BlogPostMeta[] {
-  const blogFiles = fs.readdirSync(blogDir);
-
+  let blogFiles = fs
+    .readdirSync(blogDir)
+    .filter((filename) => filename.endsWith(".md"));
+  // Exclude draft posts in production if they are somehow accidentally included
+  if (process.env.NODE_ENV !== "development") {
+    blogFiles = blogFiles.filter((filename) => !filename.endsWith(".draft.md"));
+  }
   return blogFiles
     .map((filename) => {
-      const slug = filename.replace(".md", "");
+      const slug = filename.replace(/\.md$/, "");
       const fullPath = path.join(blogDir, filename);
       const fileContents = fs.readFileSync(fullPath, "utf8");
-
       const { data, content } = matter(fileContents);
-
       return {
         slug,
         title: data.title,
         date: data.date,
         description: data.description,
         tags: data.tags ?? [],
+        postNumber:
+          typeof data.postNumber === "number"
+            ? data.postNumber
+            : typeof data.postNumber === "string"
+            ? parseInt(data.postNumber, 10)
+            : undefined,
         content,
       };
     })
     .sort((postA, postB) => (postA.date < postB.date ? 1 : -1));
 }
 
+export function getPostByNumber(
+  postNumber: number
+): { data: any; content: string; slug: string } | null {
+  const posts = getAllPosts();
+  const post = posts.find((p) => p.postNumber === postNumber);
+  if (!post) return null;
+  const fullPath = path.join(blogDir, `${post.slug}.md`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const { data, content } = matter(fileContents);
+  return { data, content, slug: post.slug };
+}
+
 export function getPost(slug: string) {
   const fullPath = path.join(blogDir, `${slug}.md`);
   const fileContents = fs.readFileSync(fullPath, "utf8");
-
   return matter(fileContents);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,4 +4,6 @@ export type BlogPostMeta = {
   date: string;
   description?: string;
   tags?: string[];
+  postNumber?: number;
+  content?: string;
 };

--- a/src/util/.htaccess
+++ b/src/util/.htaccess
@@ -1,0 +1,8 @@
+RewriteEngine On
+
+#Pages
+RewriteRule ^skills$ skills.html
+RewriteRule ^portfolio$ portfolio.html
+#RewriteRule ^portfolio/* portfolio.html
+RewriteRule ^contact$ contact.html
+RewriteRule ^blog$ blog.html


### PR DESCRIPTION
==Testing out the COPILOT PR description==

This pull request introduces several updates to the blog system, enabling blog posts to be accessed by either their slug or a numeric post number, and improves the deployment workflow by copying the `.htaccess` file for proper URL rewriting. Additionally, metadata handling and post retrieval logic have been enhanced to support these changes.

**Blog Routing and Retrieval Enhancements**
* Blog post pages can now be accessed by both slug and post number, with routing logic updated to generate static parameters for both and to retrieve posts accordingly. (`src/app/blog/[identifier]/page.tsx`, `src/lib/blog.ts`, `src/lib/types.ts`) ([src/app/blog/[identifier]/page.tsxL12-R49](diffhunk://#diff-8b6fdbfe148ff49cdbb5080c96731aa9bb46f7cda9983a5e42004aba4a8cd731L12-R49), [src/app/blog/[identifier]/page.tsxL54-L61](diffhunk://#diff-8b6fdbfe148ff49cdbb5080c96731aa9bb46f7cda9983a5e42004aba4a8cd731L54-L61), [src/app/blog/[identifier]/page.tsxL1-R1](diffhunk://#diff-8b6fdbfe148ff49cdbb5080c96731aa9bb46f7cda9983a5e42004aba4a8cd731L1-R1), [[1]](diffhunk://#diff-9ededa12db33a5cd1c2628ba50aa6600cab06c7b60d6dbf6d9aafb985a5dcda3L9-L34) [[2]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R7-R8)
* The `BlogPostMeta` type and blog post front matter now include an optional `postNumber` field, supporting the new numeric identifier feature. (`src/lib/types.ts`, `content/blog/Why-I-Added-a-Blog-to-My-Personal-Site.md`) [[1]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R7-R8) [[2]](diffhunk://#diff-7f60c3ea2922ae48dbb6c3cf7c9f069aefc573731ab35ddfaee70e9b3a9bb1dcR4)

**Deployment Workflow Improvements**
* The build and deploy workflows for both development and production now copy the `.htaccess` file into the output directory, ensuring URL rewriting rules are applied on deployment. (`.github/workflows/develop-build-deploy.yml`, `.github/workflows/production-build-deploy.yml`, `src/util/.htaccess`) [[1]](diffhunk://#diff-b0dd5ad7872b3106a70db61c97d54d73994fb7ca3968ce1446b042e5e2fb58b5R20-R21) [[2]](diffhunk://#diff-25720f1010965623d5a5fb88e598bf98afca1f3ca2c12426414d2aa6e718e9daR18-R19) [[3]](diffhunk://#diff-06c147be5e53fdb2a140d317a67aaddb477d513f650632ff5a67ce5831019fc8R1-R8)

**Blog Post Filtering**
* The blog post loader now excludes draft posts from production builds, preventing accidental publication of drafts. (`src/lib/blog.ts`)